### PR TITLE
Do not install fetchdt anymore in the hub image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,11 +86,6 @@ RUN chmod +x /usr/bin/kS4U && \
     dnf install -y perl-Authen-Krb5 && \
     dnf clean all && rm -rf /var/cache/dnf
 
-# Add Hadoop repo and install fetchdt
-ADD ./repos/hdp7-stable.repo /etc/yum.repos.d/hdp7-stable.repo
-RUN dnf -y install hadoop-fetchdt && \
-    dnf clean all && rm -rf /var/cache/dnf
-
 # Web GUI (CSS, logo)
 RUN dnf install -y unzip && \
     mkdir /usr/local/share/jupyterhub/static/swan/ && \

--- a/repos/hdp7-stable.repo
+++ b/repos/hdp7-stable.repo
@@ -1,7 +1,0 @@
-[hdp7-stable]
-name=Hadoop repository from CERN Koji [stable]
-baseurl=http://linuxsoft.cern.ch/internal/repos/hdp7-stable/x86_64/os
-enabled=1
-gpgcheck=True
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-koji file:///etc/pki/rpm-gpg/RPM-GPG-KEY-kojiv2
-priority=15


### PR DESCRIPTION
Since it has been moved to the hadoop token generator image, which is now disconnected from the hub image.

See: https://gitlab.cern.ch/swan/docker-images/hadoop-token-generator/-/merge_requests/1