### PR TITLE
Move culler and token generation scripts to the hub image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,10 @@ RUN dnf install -y unzip && \
     dnf clean all && rm -rf /var/cache/dnf \
     rm -f common.zip
 
+# Add scripts for culler (EOS tickets) and token generation
+ADD ./scripts/culler /srv/jupyterhub/culler
+ADD ./scripts/private /srv/jupyterhub/private
+
 # Make jupyterhub execute swanhub instead
 RUN ln -sf /usr/local/bin/swanhub /usr/local/bin/jupyterhub
 

--- a/scripts/culler/cull_check_ticket.sh
+++ b/scripts/culler/cull_check_ticket.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Function variables
+# 1) username for which to check ticket
+USER=$1
+
+TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+EOS_TOKENS_SECRET_NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+EOS_TOKENS_SECRET_NAME="eos-tokens-${USER}"
+
+# Get new eos token for the user
+KRB5CC_BASE64=$(bash /srv/jupyterhub/private/eos_token.sh $USER)
+if [ $? -ne 0 ]; then
+    echo "Failed to retrieve token ${EOS_TOKENS_SECRET_NAME} for ${USER}"
+    exit 1
+fi
+
+# The request body with the token exceeds the bash argument size limits.
+# So use a file with 'curl --data'
+REQUEST_BODY_FILE=$(mktemp)
+trap "rm -f ${REQUEST_BODY_FILE}" EXIT
+
+cat << EOF > $REQUEST_BODY_FILE
+{
+    "kind": "Secret",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "$EOS_TOKENS_SECRET_NAME",
+        "labels": {
+            "swan_user":"$USER"
+        }
+    },
+    "data": {
+        "krb5cc": "$KRB5CC_BASE64"
+    }
+}
+EOF
+
+# Create new secret with renewed token
+STATUS_REPLACE=$(curl -ik \
+    -s \
+    -o /dev/null \
+    -w "%{http_code}" \
+    -X PUT \
+    -H "Authorization: Bearer $TOKEN" \
+    -H 'Accept: application/json' \
+    -H 'Content-Type: application/json' \
+    -d "@$REQUEST_BODY_FILE" \
+    https://kubernetes.default.svc/api/v1/namespaces/${EOS_TOKENS_SECRET_NAMESPACE}/secrets/${EOS_TOKENS_SECRET_NAME})
+
+echo "Replacing a secret ${EOS_TOKENS_SECRET_NAMESPACE}/${EOS_TOKENS_SECRET_NAME} with token ${EOS_TOKENS_SECRET_NAMESPACE} status-create: ${STATUS_REPLACE}"
+
+case "${STATUS_REPLACE}" in
+    200)
+        exit 0
+    ;;
+    *)
+        exit 1
+    ;;
+esac
+
+

--- a/scripts/culler/cull_delete_ticket.sh
+++ b/scripts/culler/cull_delete_ticket.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Function variables
+# 1) username for which to check ticket
+USER=$1
+
+TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+EOS_TOKENS_SECRET_NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+EOS_TOKENS_SECRET_NAME="eos-tokens-${USER}"
+
+# Delete user secret
+STATUS_DELETE=$(curl -ik \
+    -o /dev/null \
+    -w "%{http_code}" \
+    -X DELETE \
+    -H "Authorization: Bearer $TOKEN" \
+    -H 'Accept: application/json' \
+    -H 'Content-Type: application/json' \
+    -d '{}' \
+    https://kubernetes.default.svc/api/v1/namespaces/${EOS_TOKENS_SECRET_NAMESPACE}/secrets/${EOS_TOKENS_SECRET_NAME})
+echo "Delete a previous secret ${EOS_TOKENS_SECRET_NAMESPACE}/${EOS_TOKENS_SECRET_NAME} status: ${STATUS_DELETE}"
+
+case "$STATUS_DELETE" in
+    200)
+        exit 0
+    ;;
+    *)
+        exit 1
+    ;;
+esac

--- a/scripts/private/eos_token.sh
+++ b/scripts/private/eos_token.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Function variables
+# 1) username for which to check ticket
+USER=$1
+
+if [[ ! -f "/srv/jupyterhub/private/eos.cred" ]]; then
+    exit 1;
+fi
+
+FILENAME="/tmp/krb5cc_$USER"
+
+kS4U -v -u $USER -s constrdt -proxy xrootd/eosuser.cern.ch,xrootd/eospublic.cern.ch,xrootd/eoshome.cern.ch,xrootd/eosatlas.cern.ch,xrootd/eoscms.cern.ch,xrootd/eoslhcb.cern.ch,xrootd/eosproject-i00.cern.ch,xrootd/eosproject-i01.cern.ch,xrootd/eosproject-i02.cern.ch -k /srv/jupyterhub/private/eos.cred -c $FILENAME > /dev/null 2>&1
+if [[ $? -ne 0 ]]; then
+    exit 1;
+fi
+
+echo $(cat $FILENAME | base64 -w 0)
+rm $FILENAME

--- a/scripts/private/sparkk8s_token.sh
+++ b/scripts/private/sparkk8s_token.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Located at [/srv/jupyterhub/private/sparkk8s-token.sh]
+
+function usage(){
+  echo -e "usage: ${0} USERNAME \n"
+  echo -e "USERNAME                      The username"
+}
+
+if [ "${1}" == "-h" ]; then
+  usage
+  exit
+fi
+
+if [[ -z "${1// }" ]]; then
+  echo "ERROR: No username set"
+  usage
+  exit 1
+fi
+USERNAME="$1"
+SERVICE_ACCOUNT="spark"
+
+KUBECONFIG="/srv/jupyterhub/private/sparkk8s.cred"
+SERVER=$(awk -F"server: " '{print $2}' ${KUBECONFIG} | sed '/^$/d')
+
+helm init --client-only > /dev/null 2>&1
+
+if user_exists=$(helm --kubeconfig "${KUBECONFIG}" ls "spark-user-${USERNAME}" > /dev/null 2>&1); then
+    :
+else
+    echo "ERROR: cluster is not ready. Please initialize cluster with helm manually"
+    exit 1
+fi
+
+if [[ -z "${user_exists// }" ]]; then
+    # User not initialized
+    helm install \
+    --wait \
+    --kubeconfig "${KUBECONFIG}" \
+    --set namespace="${USERNAME}" \
+    --set cvmfs.enable=true \
+    --name "spark-user-${USERNAME}" https://gitlab.cern.ch/db/spark-service/spark-service-charts/raw/master/cern-spark-user-1.0.2.tgz > /dev/null 2>&1
+fi
+
+# Retrieve service account secret
+SECRET=$(kubectl --kubeconfig="${KUBECONFIG}" \
+--namespace "${USERNAME}" \
+get serviceaccount "${SERVICE_ACCOUNT}" -o json | python -c 'import json,sys;obj=json.load(sys.stdin);print(obj["secrets"][0]["name"])')
+
+if [[ -z "${SECRET// }" ]]; then
+    echo "secret for SA ${SERVICE_ACCOUNT} is not found"
+    exit 1
+fi
+
+TOKEN=$(kubectl --kubeconfig="${KUBECONFIG}" \
+--namespace "${USERNAME}" \
+get secret "${SECRET}" -o json \
+| python -c 'import json,sys;obj=json.load(sys.stdin);print(obj["data"]["token"])' | base64 --decode)
+
+CA=$(kubectl --kubeconfig="${KUBECONFIG}" \
+--namespace "${USERNAME}" \
+get secret "${SECRET}" -o json \
+| python -c 'import json,sys;obj=json.load(sys.stdin);print(obj["data"]["ca.crt"])')
+
+cat > /tmp/k8s-user.config.$USERNAME <<EOF
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: $CA
+    server: $SERVER
+  name: k8s-spark-gp
+contexts:
+- context:
+    cluster: k8s-spark-gp
+    namespace: $USERNAME
+    user: spark
+  name: default
+current-context: default
+kind: Config
+preferences: {}
+users:
+- name: spark
+  user:
+    token: $TOKEN
+EOF
+
+echo $(cat /tmp/k8s-user.config.$USERNAME | base64 -w 0)
+

--- a/scripts/private/webhdfs_token.sh
+++ b/scripts/private/webhdfs_token.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Located at [/srv/jupyterhub/private/webhdfs-token.sh]
+
+#Get the namenodes for the cluster. We need to convert from the cluster name to the HDFS namespace name for nxcals and hdpqa
+function get_namenodes {
+if [ "$1" == "hadoop-nxcals" ]; then HDFSNAMESPACE='nxcals'
+elif [ "$1" == "hadoop-qa" ]; then HDFSNAMESPACE='hdpqa'
+else HDFSNAMESPACE=$1
+fi
+NAMENODES=$(xmllint --xpath '/configuration//property[name="dfs.ha.namenodes.'"$HDFSNAMESPACE"'"]/value/text()' /cvmfs/sft.cern.ch/lcg/etc/hadoop-confext/conf/etc/$1/hadoop.$1/hdfs-site.xml)
+echo "$NAMENODES"
+}
+
+CLUSTER=$1
+USER=$2
+
+# Generate HDFS, YARN, HIVE tokens
+export KRB5CCNAME=$(mktemp /tmp/hswan.XXXXXXXXX)
+kinit -V -kt /srv/jupyterhub/private/hadoop.cred hswan@CERN.CH -c $KRB5CCNAME >/dev/null 2>&1
+
+# Generate web-hdfs tokens
+if [ "$1" == "hadoop-qa" ];
+then HTTP='https'
+else HTTP='http'
+fi
+
+NAMENODES=$(get_namenodes $1)
+OIFS=$IFS
+IFS=','
+for namenode in $NAMENODES
+do
+      #to detect active NN. we cannot use jmx, we have to rely on the exit code of the list action
+      if [ $(curl -s --negotiate -u : "$HTTP://$namenode:50070/webhdfs/v1/?op=LISTSTATUS" -o /dev/null -s -w "%{http_code}") -eq 200 ];
+        then
+          WEBHDFS_TOKEN=$(curl -s --negotiate -u : "$HTTP://$namenode:50070/webhdfs/v1/?doas=$2&op=GETDELEGATIONTOKEN&renewer=yarn" | python -c 'import json,sys;obj=json.load(sys.stdin);print(obj["Token"]["urlString"])')
+        fi
+done
+
+echo $(echo $WEBHDFS_TOKEN | base64 -w 0)
+IFS=$OIFS
+kdestroy -c $KRB5CCNAME


### PR DESCRIPTION
The goal is to free the SWAN charts from containing these scripts, and place them in the image of the component that uses them.

Some strategy to allow the mounting of the dev equivalent of these scripts must be put in place in the charts themselves.