### PR TITLE
Prevent unary operator expected error when SWAN_DEV is not defined

### DIFF
--- a/scripts/private/eos_token.sh
+++ b/scripts/private/eos_token.sh
@@ -10,7 +10,7 @@ if [[ ! -f "$EOS_KEYTAB" ]]; then
     exit 1;
 fi
 
-if [ $SWAN_DEV = "true" ]; then
+if [ "$SWAN_DEV" = "true" ]; then
     # For dev purposes, one can provide already generated token
     echo $(cat /srv/jupyterhub/private/eos.cred | base64 -w 0)
     exit 0


### PR DESCRIPTION
This issue doesn't prevent the EOS ticket to be generated in production, but fills the logs with:
```
./eos_token.sh: line 13: [: =: unary operator expected
```