### PR TITLE
[JH4] Install data dumper perl module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ RUN dnf install -y python3-psycopg2 \
 
 # Install support packages
 RUN dnf install -y python3-pip \
+                   # needed by kS4U
+                   perl-Data-Dumper \
                    # needed by swanculler
                    sudo && \
     dnf clean all && rm -rf /var/cache/dnf


### PR DESCRIPTION
It is required by kS4U when generating the EOS ticket for the user.