### PR TITLE
Install kubectl and Helm from official sources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ RUN chmod +x /usr/bin/kS4U && \
 
 # Install kubectl and helm (for sparkk8s_token.sh)
 RUN curl -LO "https://dl.k8s.io/release/v1.34.4/bin/linux/amd64/kubectl" && \
-    install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && rm kubectl
-RUN curl -fsSL https://get.helm.sh/helm-v4.1.3-linux-amd64.tar.gz | tar xz && \
+    install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && rm kubectl && \
+    curl -fsSL https://get.helm.sh/helm-v4.1.3-linux-amd64.tar.gz | tar xz && \
     install -o root -g root -m 0755 linux-amd64/helm /usr/local/bin/helm && rm -rf linux-amd64
 
 # Add scripts for culler (EOS tickets) and token generation

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,10 +36,10 @@ RUN chmod +x /usr/bin/kS4U && \
     dnf clean all && rm -rf /var/cache/dnf
 
 # Install kubectl and helm (for sparkk8s_token.sh)
-ADD ./repos/kubernetes9al-stable.repo /etc/yum.repos.d/kubernetes9al-stable.repo
-RUN dnf install -y kubernetes-client && \
-    dnf install -y helm && \
-    dnf clean all && rm -rf /var/cache/dnf
+RUN curl -LO "https://dl.k8s.io/release/v1.34.4/bin/linux/amd64/kubectl" && \
+    install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && rm kubectl
+RUN curl -fsSL https://get.helm.sh/helm-v4.1.3-linux-amd64.tar.gz | tar xz && \
+    install -o root -g root -m 0755 linux-amd64/helm /usr/local/bin/helm && rm -rf linux-amd64
 
 # Add scripts for culler (EOS tickets) and token generation
 ADD ./scripts/culler /srv/jupyterhub/culler

--- a/repos/kubernetes9al-stable.repo
+++ b/repos/kubernetes9al-stable.repo
@@ -1,8 +1,0 @@
-[kubernetes9al-stable]
-name=Kubernetes clients [stable]
-baseurl=http://linuxsoft.cern.ch/internal/repos/kubernetes9al-stable/x86_64/os
-enabled=1
-gpgcheck=True
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-kojiv2
-includepkgs=kubernetes-client helm
-priority=20


### PR DESCRIPTION
Previously we were using a CERN-internal yum repo, but with the move to GitHub, this is no longer accessible from GH Actions.

However, we can just install both kubectl and Helm binaries directly.