### PR TITLE
Fix kubectl & Helm install locations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,9 +44,9 @@ RUN chmod +x /usr/bin/kS4U && \
 
 # Install kubectl and helm (for sparkk8s_token.sh)
 RUN curl -LO "https://dl.k8s.io/release/v1.34.4/bin/linux/amd64/kubectl" && \
-    install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && rm kubectl && \
+    install -o root -g root -m 0755 kubectl /usr/bin/kubectl && rm kubectl && \
     curl -fsSL https://get.helm.sh/helm-v4.1.3-linux-amd64.tar.gz | tar xz && \
-    install -o root -g root -m 0755 linux-amd64/helm /usr/local/bin/helm && rm -rf linux-amd64
+    install -o root -g root -m 0755 linux-amd64/helm /usr/bin/helm && rm -rf linux-amd64
 
 # Add scripts for culler (EOS tickets) and token generation
 COPY ./scripts/ /srv/jupyterhub/


### PR DESCRIPTION
This is fixing a bug I introduced in https://github.com/swan-cern/jupyterhub-image/pull/142

`kubectl` and `Helm` are used by the spark token generator which runs as sudo. On Alma9 (and probably other distros), `/usr/local/bin` is not on PATH when running sudo (It's missing from `secure_path` in `/etc/sudoers`).

The fix is to just install in `/usr/bin` instead which is available.

This bug is a bit sneaky because it only shows up when you run sudo. When you exec into the pod as root, `PATH` includes `/usr/local/bin` so everything appears to be working.. :laughing: 