### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/SWAN_CI_CD_pipeline.yml
+++ b/.github/workflows/SWAN_CI_CD_pipeline.yml
@@ -29,7 +29,6 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: master
-        persist-credentials: false
 
     - name: Update package version
       run: |


### PR DESCRIPTION
The CI is [failing](https://github.com/swan-cern/jupyterhub-image/actions/runs/24995087046) currently so I'm removing this again. zizmor is not going to like it, but we can come up with a proper fix later.