### PR TITLE
Remove swanotificationsservice extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ RUN pip3 install --no-cache uv && \
         keycloakauthenticator==4.0.6 \
         swanculler==1.0.7 \
         swanhub==1.0.15 \
-        swannotificationsservice==1.0.5 \
         swanspawner==1.2.47
 
 


### PR DESCRIPTION
This extension has not been used since SWAN was moved to Kubernetes, so there is no need to keep it in the Hub image, as it does not work properly in this infrastructure